### PR TITLE
Fix error in sendPing - waitForPacket is member.

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -600,7 +600,7 @@ class MQTTClient {
 	    $this->pingReqTime = time();
 
 	    // A PINGRESP packet is expected
-	    $response = waitForPacket(self::MQTT_PINGRESP);
+	    $response = $this->waitForPacket(self::MQTT_PINGRESP);
 	    if($responseHeader === false) {
 	        $this->debugMessage('Invalid packet received, expecting PINGRESP');
 	        return false;


### PR DESCRIPTION
If you try to send a ping message, you will receive an error message that waitForPacket is unknown. This is because it is no global function and the object reference is missing.