### PR TITLE
Some packages do not have a payload per definition.

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -861,7 +861,7 @@ class MQTTClient {
 	        return false;
 	    }
 
-	    $payload = $this->readBytes($packetLength);
+	    $payload = $packetLength > 0 ? $this->readBytes($packetLength) : '';
 	    if ($payload === false) {
 	        $this->lastReadStatus = self::READ_STATUS_ERROR_PAYLOAD;
 	        return false;


### PR DESCRIPTION
Some packages do [not have a payload](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718026) (for example, PINGRESP). When such a package is received from the MQTT broker, it is tried to get the payload. `fread` in `readBytes` then fails as it does not work for a length of 0 bytes.