### PR TITLE
Encode length returns false for packages without payload.

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -784,7 +784,7 @@ class MQTTClient {
 	 * @return string
 	 */
 	private function encodeLength($len) {
-	    if ($len <= 0 || $len >= 128*128*128*128) {
+	    if ($len < 0 || $len >= 128*128*128*128) {
 	        // illegal length
 	        return false;
 	    }


### PR DESCRIPTION
Some packages we send do [not have a payload](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718026). Thus, `encodeLength` is called with the length of an empty string which is 0. Instead of returning 0, `false` is returned. This package is then not recognized at least by the mosquitto broker. For example, a PINGREQ will never reach mosquitto.