### PR TITLE
Fix error in sendPing - $responseHeader is unknown and should be $response in sendPing

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -601,7 +601,7 @@ class MQTTClient {
 
 	    // A PINGRESP packet is expected
 	    $response = $this->waitForPacket(self::MQTT_PINGRESP);
-	    if($responseHeader === false) {
+	    if($response === false) {
 	        $this->debugMessage('Invalid packet received, expecting PINGRESP');
 	        return false;
 	    }


### PR DESCRIPTION
I missed an error in my last PR for sendPing: If you try to send a ping message, you will receive an error message that $responseHeader is unknown. This is because $response is used instead.