### PR TITLE
Fix error in sendSubscribe - $$topicsResult is unknown and should miss one $

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -547,7 +547,7 @@ class MQTTClient {
 	        $topicsResult[$topic] = [];
 	        if ($responsePayload[$i] > 0x02) {
 	            $topicsResult[$topic]['success'] = false;
-	            $$topicsResult[$topic]['qosGiven'] = null;
+	            $topicsResult[$topic]['qosGiven'] = null;
 	        } else {
 	            $topicsResult[$topic]['success'] = true;
 	            $topicsResult[$topic]['qosGiven'] = (int) ord($responsePayload[$i]);


### PR DESCRIPTION
sendSubscribe returns an array containing information about the successful or unsuccessful subscribe. If the subscribe was not successful, the variable used to store the QoS has one $ too much.