### PR TITLE
Fix packet loss in readPackets if $maxPackets is reached

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -887,7 +887,7 @@ class MQTTClient {
 	 */
 	private function readPackets($maxPackets = 100) {
 	    $receivedPackets = 0;
-	    while (($packet = $this->readNextPacket()) !== false && ($receivedPackets < $maxPackets)) {
+	    while (($receivedPackets < $maxPackets) && ($packet = $this->readNextPacket()) !== false) {
 	        $this->packetQueue[] = $packet;
 	        $receivedPackets++;
 	    }


### PR DESCRIPTION
In readPackets first the packet is read and afterwards it is checked whether the maximum number of packets to read is reached. If the maximum number is reached, the last retrieved packet is not added to the queue anymore. To avoid this, the check whether the maximum number of packets was read needs to be done before the next packet is read.