### PR TITLE
Fix publish for QoS 2

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -13,7 +13,7 @@ class MQTTClient {
     const MQTT_PUBLISH     = 0x30; // Publish message
     const MQTT_PUBACK      = 0x40; // Publish acknowledgment
     const MQTT_PUBREC      = 0x50; // Publish received (assured delivery part 1)
-    const MQTT_PUBREL      = 0x60; // Publish release (assured delivery part 2)
+    const MQTT_PUBREL      = 0x62; // Publish release (assured delivery part 2)
     const MQTT_PUBCOMP     = 0x70; // Publish complete (assured delivery part 3)
     const MQTT_SUBSCRIBE   = 0x80; // Client subscribe request
     const MQTT_SUBACK      = 0x90; // Subscribe acknowledgment

--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -426,7 +426,11 @@ class MQTTClient {
 	        }
 
 	        // Send PUBREL
-	        $this->sendPubRel($packetId);
+	        $response = $this->sendPubRel($packetId);
+	        if($response === false) {
+	            $this->debugMessage('Failed to send PUBREL');
+	            return false;
+	        }
 
 	        // A PUBCOMP packet is expected
 	        $response = $this->waitForPacket(self::MQTT_PUBCOMP, $packetId);

--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -426,7 +426,7 @@ class MQTTClient {
 	        }
 
 	        // Send PUBREL
-	        $this->sendPubRel($response['packetId']);
+	        $this->sendPubRel($packetId);
 
 	        // A PUBCOMP packet is expected
 	        $response = $this->waitForPacket(self::MQTT_PUBCOMP, $packetId);


### PR DESCRIPTION
If you use QoS level 2, publish will not work. There are two reasons for this:
* $response['packetId'] cannot be found as $response is a string and no array.
* At least mosquitto does not recognize the PUBREL package as the header type is wrong. According to the [specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718054), PUBREL is 0x62.