### PR TITLE
Update message receival

### DIFF
--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -971,21 +971,47 @@ class MQTTClient {
 	 * Get PUBLISH packets and return them as messages
 	 *
 	 * @param integer $maxMessages Max messages to read
-	 * @param boolean $sendPubAck If true, then send PUBACK to MQTT-server
-	 * @return string[] All PUBLISH messages
+	 * @param boolean $sendPubAck If true, then send PUBACK to MQTT-server (QoS 1)
+	 * @param boolean $sendPubRec If true, then send PUBREC to MQTT-server, wait for PUBREL and send PUBCOMP (QoS 2)
+	 * @return string[] All PUBLISH messages which were confirmed or no confirmation needed/wanted
 	 */
-	public function getPublishMessages($maxMessages = 100, $sendPubAck = false) {
-        $packetsRead = $this->readPackets($maxMessages); //$maxMessages);
+	public function getPublishMessages($maxMessages = 100, $sendPubAck = false, $sendPubRec = false) {
+        $packetsRead = $this->readPackets($maxMessages);
         $packets = $this->getQueuePackets(self::MQTT_PUBLISH);
 	    $messages = [];
 	    foreach ($packets as $key => $packet) {
 	        $message = $this->decodePublish($packet);
-	        if ($message) {
-	            $messages[] = $message;
-	            if ($sendPubAck && ($message['qos'] == self::MQTT_QOS1)) {
-	                $this->sendPubAck($message['packetId']);
-	            }
+	        if ($message === false) {
+	            $this->debugMessage('Message could not be decoded');
+	            continue;
 	        }
+	        
+            if ($sendPubAck && ($message['qos'] == self::MQTT_QOS1)) {
+                if($this->sendPubAck($message['packetId']) === false) {
+                    $this->debugMessage('Failed to send PUBACK');
+                    continue;
+                }
+            } elseif ($sendPubRec && ($message['qos'] == self::MQTT_QOS2)) {
+                // Send PUBREC
+                if($this->sendPubRec($message['packetId']) === false) {
+                    $this->debugMessage('Failed to send PUBREC');
+                    continue;
+                }
+                // A PUBREL packet is expected
+                $response = $this->waitForPacket(self::MQTT_PUBREL, $message['packetId']);
+                if($response === false) {
+                    $this->debugMessage('Packet missing, expecting PUBREL');
+                    continue;
+                }
+                // Send PUBCOMP
+                if($this->sendPubComp($message['packetId']) === false) {
+                    $this->debugMessage('Failed to send PUBCOMP');
+                    continue;
+                }
+            }
+            
+            // Package was successfully confirmed or no confirmation needed/wanted --> store it
+            $messages[] = $message;
 	    }
 	    return $messages;
 	}

--- a/MQTTClient.php
+++ b/MQTTClient.php
@@ -937,7 +937,7 @@ class MQTTClient {
 	 */
 	private function isPacketVerified($packet, $header, $verifyPacketId = false) {
 	    if (is_string($packet) && strlen($packet) >= 1) {
-    	    if ((int)(ord($packet[0])&0xf0) == (int)$header) {
+	        if ((int)(ord($packet[0])&0xf0) == (int)($header&0xf0)) {
     	        if ($verifyPacketId === false) return true;
 	            if (strlen($packet) >= 3) {
 	                $receivedPacketId = (int)(ord($packet[1])<<8) + ord($packet[2]);


### PR DESCRIPTION
The retrieval of messages did not support QoS 2 and also did not follow the official protocol in the specification. This could lead to multiple processing of messages.

**Changes done:**
* Comparison in isPacketVerified should only consider the non-reserved bits, also for the header. This is important as the header for PUBREL is 0x62 (see #18), but from the received header we can only use the non-reserved bits to avoid issues with publish. This is only an issue when waiting for PUBREL which is required for QoS 2.
* Do not store the message anymore when we fail to send the PUBACK in QoS 1. The server will resend the message for sure when we connect the next time as the receival was never confirmed.
* Add support for the QoS 2 steps. We will not store the message if we cannot complete the confirmation of the receival. However, this can lead to further issues (see next section).

**Open issue (where I do not know how to solve it):**
A server "MUST NOT re-send the PUBLISH once it has sent the corresponding PUBREL packet." [1] This can cause issues once the server received our PUBREC and sent the first PUBREL. We will only get multiple PUBREL afterwards, but never get the message content again.
* We will lose the message content in this implementation if the confirmation fails.
* If we store the message content in a class variable until the confirmation was successful, we will lose it if the MQTTClient instance is destroyed. Additionally, all incoming messages need to be checked whether a PUBREL is received. If a PUBREL is received, we need to send the corresponding PUBCOMP and consider the package during the next message retrieval, but do not send the PUBREC again.
* If we process the message as soon as PUBREC is sent successfully, we also need to check all incoming packets for a PUBREL and confirm all PUBREL packets we retrieve. Additionally we might violate the QoS 2 if the server does not receive the PUBREC and then sends the message again.
To me it seems that this can only be resolved if we persist all retrieved QoS 2 messages in a database and check against the database.

[1] http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718102

**Conclusion:**
I would say, that publish is working fine in all QoS levels, but retrieval has restrictions if used with QoS 2. It is up to you whether you want to have this feature added including the limitations or better make the limitation public that retrieval of QoS 2 is possible but the confirmation not and reject this PR.