### PR TITLE
Composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,16 @@
 {
-    "name": "karpy47/PhpMqttClient",
+    "name": "karpy47/php-mqtt-client",
     "description": "MQTT 3.1.1 library for PHP with TLS support",
     "keywords": [ "mqtt", "client", "php" ],
-    "version": "1.0.2",
     "license": "MIT",
     "authors": [
-        { 
-            "name": "karpy47" 
+        {
+            "name": "karpy47"
         }
     ],
     "autoload": {
-        "psr-4": { 
-            "karpy47\\PhpMqttClient\\": "" 
+        "psr-4": {
+            "karpy47\\PhpMqttClient\\": ""
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Tagging version 1.0.3 for #25 did not get a the new version to show up on composers :(

needed to remove the version field from the composer file
also fixed the `name` to match best practice (lower-cased/with-dashes) and its published name

this will want 1.0.4 tagging after merge